### PR TITLE
Switch to granular structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+  - 7.3
+  - 7.4
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer install --prefer-source --no-interaction
+
+script:
+  - composer test-ci

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,20 @@
       "Shalvah\\Clara\\": "src"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Shalvah\\Clara\\Tests\\": "tests"
+    }
+  },
   "require": {
     "php": ">=7.2.5",
     "symfony/console": "^5.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.1"
+  },
+  "scripts": {
+    "test": "phpunit tests --stop-on-failure",
+    "test-ci": "phpunit tests"
   }
 }

--- a/src/Clara.php
+++ b/src/Clara.php
@@ -10,47 +10,87 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 class Clara
 {
     public static $CLARA_ON = true;
+    
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var bool
+     */
+    private $on;
+    /**
+     * @var array
+     */
+    public $captures;
 
-    public static function success($output)
+    public function __construct(string $name)
     {
-        return static::output("👍 success <info>$output </info>");
+        $this->name = $name;
+        $this->on = true;
+        $this->captures = [];
     }
 
-    public static function info($output)
+    public static function app(string $name)
     {
-        return static::output("<info>🔊 info</info> {$output}");
+        return new static($name);
+    }
+    
+    public function success($text)
+    {
+        return $this->line("👍 success <info>$text </info>");
     }
 
-    public static function debug($output)
+    public function info($text)
     {
-        return static::output("<fg=blue>🐛 debug</> {$output}");
+        return $this->line("<info>🔊 info</info> {$text}");
     }
 
-    public static function warn($output)
+    public function debug($text)
     {
-        return static::output("<fg=yellow>🚸 warning</> {$output}");
+        return $this->line("<fg=blue>🐛 debug</> {$text}");
     }
 
-    public static function error($output)
+    public function warn($text)
     {
-        return static::output("<fg=red>🚫 error</> {$output}");
+        return $this->line("<fg=yellow>🚸 warning</> {$text}");
+    }
+
+    public function error($text)
+    {
+        return $this->line("<fg=red>🚫 error</> {$text}");
     }
 
     /**
      * Output the given text to the console.
      */
-    public static function output($output = "")
+    public function line($text = "")
     {
-        static::$CLARA_ON && (new ConsoleOutput)->writeln($output);
-        return $output;
+        if (static::$CLARA_ON && $this->on) {
+            (new ConsoleOutput)->writeln($text);
+        } else {
+            $this->captures[] = $text;
+        }
+        return $text;
     }
 
-    public static function mute()
+    public function mute()
+    {
+        $this->on = false;
+        $this->captures = [];
+    }
+
+    public function unmute()
+    {
+        $this->on = true;
+    }
+
+    public static function muteGlobal()
     {
         static::$CLARA_ON = false;
     }
 
-    public static function unmute()
+    public static function unmuteGlobal()
     {
         static::$CLARA_ON = true;
     }

--- a/tests/ClaraTest.php
+++ b/tests/ClaraTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Shalvah\Clara\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Shalvah\Clara\Clara;
+use Symfony\Component\Console\Output\NullOutput;
+
+class ClaraTest extends TestCase
+{
+
+    protected function tearDown(): void
+    {
+        Clara::reset();
+    }
+
+    public function test_mute_without_args_mutes_all()
+    {
+        $nullOutput = $this->createMock(NullOutput::class);
+        $output = new Clara('app1', $nullOutput);
+
+        $nullOutput->expects($this->once())
+            ->method('writeln')
+            ->with("App 1 - Output 1");
+        $output->line("App 1 - Output 1");
+
+        Clara::mute();
+
+        $output->line("App 1 - Output 2");
+        (new Clara('app1', $nullOutput))->line("App 2 - Output 1");
+    }
+
+    public function test_mute_with_arg_mutes_only_app()
+    {
+        $nullOutput = $this->createMock(NullOutput::class);
+        $output = new Clara('app1', $nullOutput);
+
+        $nullOutput->expects($this->once())
+            ->method('writeln')
+            ->with("App 1 - Output 1");
+        $output->line("App 1 - Output 1");
+
+        Clara::mute('app1');
+        $output->line("App 1 - Output 2");
+
+        $nullOutput2 = $this->createMock(NullOutput::class);
+        $nullOutput2->expects($this->once())
+            ->method('writeln')
+            ->with("App 2 - Output 1");
+        (new Clara('app2', $nullOutput2))->line("App 2 - Output 1");
+    }
+
+    public function test_unmute_without_args_unmutes_all()
+    {
+        $nullOutput = $this->createMock(NullOutput::class);
+        $output = new Clara('app1', $nullOutput);
+
+        Clara::mute();
+        $output->line("App 1 - Output 1");
+        (new Clara('app1', $nullOutput))->line("App 2 - Output 1");
+
+        Clara::unmute();
+        $output->line("App 1 - Output 2");
+        (new Clara('app1', $nullOutput))->line("App 2 - Output 2");
+
+        Clara::mute('app1');
+        $output->line("App 1 - Output 3");
+
+        Clara::unmute();
+        $output->line("App 1 - Output 4");
+    }
+
+    public function test_unmute_with_arg_unmutes_only_app()
+    {
+        $nullOutput = $this->createMock(NullOutput::class);
+        $output = new Clara('app1', $nullOutput);
+
+        Clara::mute();
+        $output->line("App 1 - Output 1");
+        (new Clara('app1', $nullOutput))->line("App 2 - Output 1");
+
+        Clara::unmute('app2');
+        $output->line("App 1 - Output 2");
+        (new Clara('app1', $nullOutput))->line("App 2 - Output 2");
+    }
+}


### PR DESCRIPTION
Migrating from static calls to a per-app setup.

Before:
```php
Clara::info("Installing package");
```

After:
```php
$output = Clara::app('myappname');
$output->info("Installing package");
```

A bit more verbose, but it allows us to do things like mute only a specific app's logs (included in this PR) and is more easily testable.
