### PR TITLE
Implement output capturing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shalvah/clara",
-  "description": "🔊 Simple, pretty console output for CLI apps.",
+  "description": "🔊 Simple, pretty, testable console output for CLI apps.",
   "keywords": [
     "log",
     "logging",
@@ -22,7 +22,8 @@
     "symfony/console": "^5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.1"
+    "phpunit/phpunit": "^9.1",
+    "eloquent/phony-phpunit": "^7.0"
   },
   "scripts": {
     "test": "phpunit tests --stop-on-failure",

--- a/tests/ClaraTest.php
+++ b/tests/ClaraTest.php
@@ -2,6 +2,7 @@
 
 namespace Shalvah\Clara\Tests;
 
+use Eloquent\Phony\Phpunit\Phony;
 use PHPUnit\Framework\TestCase;
 use Shalvah\Clara\Clara;
 use Symfony\Component\Console\Output\NullOutput;
@@ -16,71 +17,87 @@ class ClaraTest extends TestCase
 
     public function test_mute_without_args_mutes_all()
     {
-        $nullOutput = $this->createMock(NullOutput::class);
-        $output = new Clara('app1', $nullOutput);
+        $handle = Phony::mock(NullOutput::class);
+        $nullOutput = $handle->get();
+        $app1 = new Clara('app1', $nullOutput);
+        $app2 = new Clara('app2', $nullOutput);
 
-        $nullOutput->expects($this->once())
-            ->method('writeln')
-            ->with("App 1 - Output 1");
-        $output->line("App 1 - Output 1");
+        $app1->line("App 1 - Output 1");
 
         Clara::mute();
 
-        $output->line("App 1 - Output 2");
-        (new Clara('app1', $nullOutput))->line("App 2 - Output 1");
+        $app1->line("App 1 - Output 2");
+        $app2->line("App 2 - Output 1");
+
+        $handle->writeln->once()->called();
+        $handle->writeln->firstCall()->calledWith("App 1 - Output 1");
     }
 
     public function test_mute_with_arg_mutes_only_app()
     {
-        $nullOutput = $this->createMock(NullOutput::class);
-        $output = new Clara('app1', $nullOutput);
+        $handle = Phony::mock(NullOutput::class);
+        $nullOutput = $handle->get();
 
-        $nullOutput->expects($this->once())
-            ->method('writeln')
-            ->with("App 1 - Output 1");
-        $output->line("App 1 - Output 1");
+        $app1 = new Clara('app1', $nullOutput);
+        $app2 = new Clara('app2', $nullOutput);
+
+        $app1->line("App 1 - Output 1");
 
         Clara::mute('app1');
-        $output->line("App 1 - Output 2");
+        $app1->line("App 1 - Output 2");
 
-        $nullOutput2 = $this->createMock(NullOutput::class);
-        $nullOutput2->expects($this->once())
-            ->method('writeln')
-            ->with("App 2 - Output 1");
-        (new Clara('app2', $nullOutput2))->line("App 2 - Output 1");
+        $app2->line("App 2 - Output 1");
+
+        $handle->writeln->twice()->called();
+        $handle->writeln->firstCall()->calledWith("App 1 - Output 1");
+        $handle->writeln->lastCall()->calledWith("App 2 - Output 1");
     }
 
     public function test_unmute_without_args_unmutes_all()
     {
-        $nullOutput = $this->createMock(NullOutput::class);
-        $output = new Clara('app1', $nullOutput);
+        $handle = Phony::mock(NullOutput::class);
+        $nullOutput = $handle->get();
+        $app1 = new Clara('app1', $nullOutput);
+        $app2 = new Clara('app2', $nullOutput);
 
         Clara::mute();
-        $output->line("App 1 - Output 1");
-        (new Clara('app1', $nullOutput))->line("App 2 - Output 1");
+        $app1->line("App 1 - Output 1");
+        $app2->line("App 2 - Output 1");
 
         Clara::unmute();
-        $output->line("App 1 - Output 2");
-        (new Clara('app1', $nullOutput))->line("App 2 - Output 2");
+        $app1->line("App 1 - Output 2");
+        $app2->line("App 2 - Output 2");
+
+        $handle->writeln->twice()->called();
+        $handle->writeln->firstCall()->calledWith("App 1 - Output 2");
+        $handle->writeln->lastCall()->calledWith("App 2 - Output 2");
 
         Clara::mute('app1');
-        $output->line("App 1 - Output 3");
+        $app1->line("App 1 - Output 3");
 
         Clara::unmute();
-        $output->line("App 1 - Output 4");
+        $app1->line("App 1 - Output 4");
+
+        $handle->writeln->thrice()->called();
+        $handle->writeln->lastCall()->calledWith("App 1 - Output 4");
     }
 
     public function test_unmute_with_arg_unmutes_only_app()
     {
-        $nullOutput = $this->createMock(NullOutput::class);
-        $output = new Clara('app1', $nullOutput);
+        $handle = Phony::mock(NullOutput::class);
+        $nullOutput = $handle->get();
+        $app1 = new Clara('app1', $nullOutput);
+        $app2 = new Clara('app2', $nullOutput);
 
         Clara::mute();
-        $output->line("App 1 - Output 1");
-        (new Clara('app1', $nullOutput))->line("App 2 - Output 1");
+        $app1->line("App 1 - Output 1");
+        $app2->line("App 2 - Output 1");
 
         Clara::unmute('app2');
-        $output->line("App 1 - Output 2");
-        (new Clara('app1', $nullOutput))->line("App 2 - Output 2");
+        $app1->line("App 1 - Output 2");
+        $app2->line("App 2 - Output 2");
+
+        $handle->writeln->once()->called();
+        $handle->writeln->lastCall()->calledWith("App 2 - Output 2");
     }
 }


### PR DESCRIPTION
Add ability to capture the output per app.


```php
Clara::startCapturingOutput('myapp1'); // Clara will start capturing output from myapp1
$output1 = Clara::app('myapp1');
$output1->warn("Going to fail");
$output1->error("Failed");

$capturedOutput = Clara::getCapturedOutput('myapp1');
// $capturedOutput = [
//   "<fg=yellow>🚸 warning</> Going to fail",
//   "<fg=red>🚫 error</> Failed",
// ]

Clara::stopCapturingOutput('myapp1');
Clara::clearCapturedOutput('myapp1'); // Will empty saved output
``` 