### PR TITLE
Allow symfony/console package version 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": ">=7.4",
-    "symfony/console": "^4.0|^5.0|^6.0"
+    "symfony/console": "^4.0|^5.0|^6.0|^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.1",


### PR DESCRIPTION
This fixes Laravel 11.x and Symfony 7.x conflicts